### PR TITLE
GOML3: fix post-install script for node 6

### DIFF
--- a/dist/lib/git-off-my-land-lib.js
+++ b/dist/lib/git-off-my-land-lib.js
@@ -79,7 +79,8 @@ async function filterFilesList(rawStdOut, ignoreGitStatusResultPrefixes, EOLChar
     return p;
 }
 
-async function scanFilteredFiles(committedFiles, fileContentRegexps, violatingFilenameExtensions, filesToIgnore) {
+async function scanFilteredFiles(committedFiles, fileContentRegexps, violatingFilenameExtensions, filesToIgnore) //eslint-disable-line complexity
+{
     if (!(committedFiles instanceof Set)) {
         throw new TypeError("Value of argument \"committedFiles\" violates contract.\n\nExpected:\nSet\n\nGot:\n" + _inspect(committedFiles));
     }
@@ -129,7 +130,8 @@ async function scanFilteredFiles(committedFiles, fileContentRegexps, violatingFi
 
                     // Filename extension-based scanning
                     const extension = (0, _path.extname)(committedFile).toLocaleLowerCase();
-                    for (let k in violatingFilenameExtensions) {
+                    for (let k in violatingFilenameExtensions) // eslint-disable-line no-unused-vars
+                    {
                         if (violatingFilenameExtensions.includes(extension) === true) {
                             rawViolations[committedFile]["extension"].push(extension);
                             break;
@@ -138,7 +140,6 @@ async function scanFilteredFiles(committedFiles, fileContentRegexps, violatingFi
                 }
         }
 
-        // TODO -> Array.filter() 
         // Prune any empty array items
         let prunedViolations = [];
         for (let violation in rawViolations) {
@@ -149,7 +150,6 @@ async function scanFilteredFiles(committedFiles, fileContentRegexps, violatingFi
             }
         }
 
-        // TODO -> Array.filter()        
         // Filter for files the user has chosen to ignore
         for (let violation in prunedViolations) {
             let ignore = false;

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
         "create-report": "./node_modules/.bin/nyc report --reporter=lcov --reporter=html",
         "show-report": "open coverage/index.html",
         "report": "npm run create-report && npm run show-report",
-        "build": "./node_modules/babel-cli/bin/babel.js src/ --out-dir dist",
-        "postinstall": "./scripts/post-install.js",
+        "build": "./node_modules/babel-cli/bin/babel.js src/ --out-dir dist && ./node_modules/babel-cli/bin/babel.js scripts/src/ --out-dir scripts/dist",
+        "postinstall": "./scripts/dist/post-install.js",
         "preversion": "npm run build && npm test && npm run create-report",
         "version": "npm run vuln-scan && git add -A",
         "postversion": "git push --follow-tags && npm publish"

--- a/scripts/dist/post-install.js
+++ b/scripts/dist/post-install.js
@@ -1,0 +1,80 @@
+#! /usr/bin/env node
+
+"use strict";
+
+// Note that this file is kept deliberately simple as it doesn't go through the babel build process...
+// ... and yes, it's all sync and horrible but it's a post-install script so ;-)
+
+const path = require("path");
+const fs = require("fs");
+
+const ts = new Date().getTime();
+
+const srcBaseDir = process.cwd();
+// NOTE:
+// process.env.INIT_CWD is intended to allow this script to run on local file: based installs but, it only works on modern node versions
+// On node 6 (at least), process.cwd() is node the location from which `npm install` is run, it's the installation dir of this node module i.e. <pwd>/node_modules/git-off-my-land/
+// Unsure why this isn't the case for srcBaseDir, above...
+let destBaseDir = process.env.INIT_CWD || process.cwd();
+
+// "fix" node 6-like behaviour to get the correct dir name (strip "node_modules/git-off-my-land" from the end)
+const destBaseDirArr = destBaseDir.split("/");
+if (destBaseDirArr.pop() === "git-off-my-land" && destBaseDirArr.pop() === "node_modules") {
+  destBaseDir = destBaseDirArr.join("/");
+}
+
+const configSrcDir = path.join(srcBaseDir, "/config");
+const configDestDir = path.join(destBaseDir, "/config");
+const configFilename = "git-off-my-land-config.js";
+const configSrcFile = path.join(configSrcDir, "/", configFilename);
+const configDestFile = path.join(configDestDir, "/", configFilename);
+const configDestFileAlt = path.join(configDestDir, "/", `new-${ts}-configFilename`);
+
+const hookSrcDir = path.join(srcBaseDir, "/hooks");
+const hookDestDir = path.join(destBaseDir, "/.git/hooks");
+const hookFilename = "pre-commit";
+const hookSrcFile = path.join(hookSrcDir, "/", hookFilename);
+const hookDestFile = path.join(hookDestDir, "/", hookFilename);
+const hookDestFileAlt = path.join(hookDestDir, "/", `new-${ts}-hookFilename`);
+
+// TODO: Make this neater
+try {
+  fs.mkdirSync(configDestDir); // eslint-disable-line no-sync
+} catch (e) {
+  if (e.code !== "EEXIST") // Don't fail on existing dir
+    {
+      console.error(e);
+    }
+}
+
+try {
+  const confFile = fs.readFileSync(configSrcFile); // eslint-disable-line no-sync
+  fs.writeFileSync(configDestFile, confFile); // eslint-disable-line no-sync
+} catch (e) {
+  if (e.code === "EEXIST") // Don't overwrite existing file, write to alt file instead
+    {
+      console.warn(`WARNING! Existing git-off-my-land config file - updated file copied to ${configDestFileAlt}. Please merge your existing config into the new format if it's changed`);
+      const confFile = fs.readFileSync(configSrcFile); // eslint-disable-line no-sync
+      fs.writeFileSync(configDestFileAlt, confFile); // eslint-disable-line no-sync
+    } else {
+    console.error(e);
+  }
+}
+
+const hookFileOptions = {
+  mode: 0o755
+};
+
+try {
+  const hookFile = fs.readFileSync(hookSrcFile); // eslint-disable-line no-sync
+  fs.writeFileSync(hookDestFile, hookFile, hookFileOptions); // eslint-disable-line no-sync
+} catch (e) {
+  if (e.code === "EEXIST") // Don't overwrite existing file, write to alt file instead
+    {
+      console.warn(`WARNING! Existing git-off-my-land githook file - updated file copied to ${hookDestFileAlt}. Please replace your existing hook file if you have not modified it or merge changes if you have`);
+      const hookFile = fs.readFileSync(hookSrcFile); // eslint-disable-line no-sync
+      fs.writeFileSync(hookDestFileAlt, hookFile, hookFileOptions); // eslint-disable-line no-sync
+    } else {
+    console.error(e);
+  }
+}


### PR DESCRIPTION
Manually tested on node 6, 8 and 10. Had to switch fs.copyFileSync for read then write sync.